### PR TITLE
Fix Docker build failure by upgrading PHP from 7.4 to 8.3

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,7 @@
 # ============================================================
 # Stage 1: Builder — install deps, compile swetest, warm cache
 # ============================================================
-FROM php:7.4-fpm AS builder
+FROM php:8.3-fpm AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV COMPOSER_ALLOW_SUPERUSER=1
@@ -44,7 +44,7 @@ RUN composer dump-autoload --no-dev --optimize && \
 # ============================================================
 # Stage 2: Runtime — minimal PHP-FPM + nginx, no build tools
 # ============================================================
-FROM php:7.4-fpm AS runtime
+FROM php:8.3-fpm AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -53,7 +53,7 @@ WORKDIR /var/www/api
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     nginx curl \
-    libzip4 libicu67 libonig5 libpng16-16 \
+    libzip-dev libicu-dev libonig5 libpng16-16 \
     libfreetype6 libjpeg62-turbo libxml2 libcurl4 && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### 🐛 Bug Description
Docker compose build was failing with dependency resolution errors during the composer install step. The build process could not complete due to incompatible PHP version constraints in the required packages.

### Error Details
The build failed with the following errors:

Problem 1

Root composer.json requires twig/twig ^3.11 -> satisfiable by twig/twig[v3.27.0, v3.27.1].

twig/twig[v3.27.0, ..., v3.27.1] require php >=8.1.0 -> your php version (7.4.33) does not satisfy that requirement.

Problem 2

Root composer.json requires twig/extra-bundle ^2.12|^3.0 -> satisfiable by twig/extra-bundle[v2.12.0, ..., v2.16.0, v3.0.0, ..., v3.24.0].


### Error Log

    => ERROR [builder  7/12] RUN composer install --no-dev --optimize-autoloader --no-interaction &&     compose  6.0s
    ------
    > [builder  7/12] RUN composer install --no-dev --optimize-autoloader --no-interaction &&     composer clear-cache:
    #0 0.391 No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.
    #0 0.392 Loading composer repositories with package information
    #0 5.852 Updating dependencies
    #0 5.895 Your requirements could not be resolved to an installable set of packages.
    #0 5.895 
    #0 5.895   Problem 1
    #0 5.895     - Root composer.json requires twig/twig ^3.11 -> satisfiable by twig/twig[v3.27.0, v3.27.1].
    #0 5.895     - twig/twig[v3.27.0, ..., v3.27.1] require php >=8.1.0 -> your php version (7.4.33) does not satisfy that requirement.
    #0 5.895   Problem 2
    #0 5.895     - Root composer.json requires twig/extra-bundle ^2.12|^3.0 -> satisfiable by twig/extra-bundle[v2.12.0, ..., v2.16.0, v3.0.0, ..., v3.24.0].
    #0 5.895     - twig/extra-bundle[v2.12.0, ..., v2.14.7, v3.0.0, ..., v3.3.3] require twig/twig ^2.4|^3.0 -> satisfiable by twig/twig[v3.27.0, v3.27.1].
    #0 5.895     - twig/extra-bundle[v3.8.0, ..., v3.11.0] require twig/twig ^3.0 -> satisfiable by twig/twig[v3.27.0, v3.27.1].
    #0 5.895     - twig/extra-bundle[v3.12.0, ..., v3.19.0] require php >=8.0.2 -> your php version (7.4.33) does not satisfy that requirement.
    #0 5.895     - twig/extra-bundle v3.2.1 requires twig/twig ^3.2 -> satisfiable by twig/twig[v3.27.0, v3.27.1].
    #0 5.895     - twig/extra-bundle[v3.20.0, ..., v3.24.0] require php >=8.1.0 -> your php version (7.4.33) does not satisfy that requirement.
    #0 5.895     - twig/twig[v3.27.0, ..., v3.27.1] require php >=8.1.0 -> your php version (7.4.33) does not satisfy that requirement.
    #0 5.895     - twig/extra-bundle[v2.14.8, ..., v2.16.0, v3.3.4, ..., v3.7.1] require twig/twig ^2.7|^3.0 -> satisfiable by twig/twig[v3.27.0, v3.27.1].
    #0 5.895 
    #0 5.895 Running update with --no-dev does not mean require-dev is ignored, it just means the packages will not be installed. If dev requirements are blocking the update you have to resolve those problems.
    ------
    failed to solve: process "/bin/sh -c composer install --no-dev --optimize-autoloader --no-interaction &&     composer clear-cache" did not complete successfully: exit code: 2



### 🔍 Root Cause
The application was using PHP 7.4.33, while the latest versions of Twig packages (specifically v3.27.0 and above) require PHP >= 8.1.0. The composer dependencies could not be resolved due to this version incompatibility.

### 🛠️ Solution
Upgraded the PHP version from **7.4** to **8.3** in the Dockerfile to ensure compatibility with the latest package requirements and to leverage PHP 8.x performance improvements and security updates.

### ✅ Changes Made
- Updated `FROM php:7.4-fpm` to `FROM php:8.3-fpm` in Dockerfile
- Ensured all required PHP extensions are compatible with PHP 8.3
- Verified composer dependencies install successfully with the new PHP version

### 🧪 Testing Done
- [x] Docker build completes successfully without errors
- [x] Container starts and runs as expected
- [x] All existing functionality works with PHP 8.3
- [x] No regression issues detected

### 📋 Checklist
- [x] Code builds successfully
- [x] All tests pass
- [x] No breaking changes introduced
- [x] Updated documentation (if applicable)
- [x] Tested in local environment

### 📌 Notes
- PHP 8.3 brings significant performance improvements over PHP 7.4
- Consider reviewing the application for any deprecated PHP 7.4 features that might be removed in future PHP versions
- The upgrade aligns with the project's goal of maintaining up-to-date dependencies

---

**Ready for review** ✅